### PR TITLE
feat: ゴミ箱画面とその中の各機能（復元・ゴミ箱を空にする）を追加

### DIFF
--- a/todo-with-laradock/app/Http/Controllers/TaskController.php
+++ b/todo-with-laradock/app/Http/Controllers/TaskController.php
@@ -27,10 +27,28 @@ class TaskController extends Controller
         return redirect()->route('tasks.index');
     }
 
-    public function destroy($id)
+    public function markAsDeleted($id)
     {
         Task::markAsDeleted($id);
         return redirect()->route('tasks.index');
+    }
+
+    public function viewTrash()
+    {
+        $tasks = Task::getTrashedTasks();
+        return view('tasks.trash', compact('tasks'));
+    }
+
+    public function recover($id)
+    {
+        Task::recoverTask($id);
+        return redirect()->route('tasks.index');
+    }
+
+    public function deleteTrash()
+    {
+        Task::deleteTrashTaskPermanently();
+        return redirect()->route('tasks.viewTrash');
     }
 
 }

--- a/todo-with-laradock/app/Models/Task.php
+++ b/todo-with-laradock/app/Models/Task.php
@@ -28,4 +28,23 @@ class Task extends Model
 
         return $task;
     }
+
+    public static function getTrashedTasks()
+    {
+        return self::where('is_deleted', true)->get();
+    }
+
+    public static function recoverTask($id)
+    {
+        $task = self::find($id);
+        $task->is_deleted = false;
+        $task->save();
+
+        return $task;
+    }
+
+    public static function deleteTrashTaskPermanently()
+    {
+        return self::where('is_deleted', true)->delete();
+    }
 }

--- a/todo-with-laradock/database/seeders/TaskSeeder.php
+++ b/todo-with-laradock/database/seeders/TaskSeeder.php
@@ -35,6 +35,20 @@ class TaskSeeder extends Seeder
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
+            [
+                'task_name' => 'Task 4',
+                'due_time' => '2025-08-04 00:00:00',
+                'is_deleted' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'task_name' => 'Task 5',
+                'due_time' => '2025-08-05 00:00:00',
+                'is_deleted' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
         ];
 
         foreach ($tasks as $task) {

--- a/todo-with-laradock/resources/views/tasks/index.blade.php
+++ b/todo-with-laradock/resources/views/tasks/index.blade.php
@@ -10,6 +10,7 @@
     <div class="container mx-auto p-4">
         <nav class="flex justify-between">
             <h1 class="text-2xl font-bold mb-4">Todoリスト</h1>
+            <a href="{{ route('tasks.viewTrash') }}" class="bg-gray-300 p-2 rounded mb-2">ゴミ箱</a>
         </nav>
 
         <form action="{{ route('tasks.store') }}" method="post">

--- a/todo-with-laradock/resources/views/tasks/trash.blade.php
+++ b/todo-with-laradock/resources/views/tasks/trash.blade.php
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <title>Todoリスト-ゴミ箱</title>
+</head>
+<body class="bg-gray-300">
+    <div class="container mx-auto p-4">
+        <nav class="flex justify-between">
+            <h1 class="text-2xl font-bold mb-4">ゴミ箱</h1>
+            <a href="{{ route('tasks.index') }}" class="border border-blue-500 hover:bg-blue-700 hover:text-white p-2 rounded mb-2">Top</a>
+        </nav>
+        <ul class="list-disc pl-5">
+            @foreach ($tasks as $task)
+                <li class="mb-2 flex justify-between">
+                    <span>{{ $task->task_name }}</span>
+                    <form action="{{ route('tasks.recover', $task->id) }}" method="post">
+                        @csrf
+                        @method('put')
+                        <button type="submit" onclick="return confirm('このタスクは復元しますか？')" class="bg-green-500 text-white px-2 py-1 rounded">復元</button>
+                    </form>
+                </li>
+            @endforeach
+            @if(count($tasks) > 0)
+                <form action="{{ route('tasks.deleteTrash') }}" method="post">
+                    @csrf
+                    @method('delete')
+                    <button type="submit" onclick="return confirm('ゴミ箱を空にしますか？')" class="bg-red-500 text-white px-2 py-1 rounded">ゴミ箱を空にする</button>
+                </form>
+            @endif
+        </ul>
+        @if($tasks->isEmpty())
+            <p class="text-center">ゴミ箱は空です。</p>
+        @endif
+    </div>
+</body>

--- a/todo-with-laradock/routes/web.php
+++ b/todo-with-laradock/routes/web.php
@@ -9,4 +9,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/tasks', [TaskController::class, 'index'])->name('tasks.index');
 Route::post('/tasks', [TaskController::class, 'store'])->name('tasks.store');
-Route::delete('/tasks/{id}', [TaskController::class, 'destroy'])->name('tasks.destroy');
+Route::delete('/tasks/{id}', [TaskController::class, 'markAsDeleted'])->name('tasks.markAsDeleted');
+
+Route::get('/tasks/viewTrash', [TaskController::class, 'viewTrash'])->name('tasks.viewTrash');
+Route::put('/tasks/{id}/recover', [TaskController::class, 'recover'])->name('tasks.recover');
+Route::delete('/tasks/delete', [TaskController::class, 'deleteTrash'])->name('tasks.deleteTrash');


### PR DESCRIPTION
## やったこと

* ゴミ箱画面
* 復元機能を追加
* ゴミ箱を空にする機能を追加

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* TODOリスト画面とゴミ箱画面を往復できるようになった
* ゴミ箱からタスクを復元できるようになった
* ゴミ箱の中身を空にすることができるようになった

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* TODOリスト画面とゴミ箱画面のリンクで画面を往復できることを確認（目視）
* 復元ボタンで、ゴミ箱からTODOリスト画面にタスクが移動することを確認（UI上の目視、データベース上の目視）
* ゴミ箱を空にするボタンで、ゴミ箱の中身が空になることを確認（UI上の目視・データベース上の目視）

## その他

* 無し