### PR TITLE
fix: 『ゴミ箱を空にする』ボタンを押した時に、関係のないルーティングが実行されるエラーを修正

### DIFF
--- a/todo-with-laradock/routes/web.php
+++ b/todo-with-laradock/routes/web.php
@@ -13,4 +13,4 @@ Route::delete('/tasks/{id}', [TaskController::class, 'markAsDeleted'])->name('ta
 
 Route::get('/tasks/viewTrash', [TaskController::class, 'viewTrash'])->name('tasks.viewTrash');
 Route::put('/tasks/{id}/recover', [TaskController::class, 'recover'])->name('tasks.recover');
-Route::delete('/tasks/delete', [TaskController::class, 'deleteTrash'])->name('tasks.deleteTrash');
+Route::delete('/tasks/trash/delete', [TaskController::class, 'deleteTrash'])->name('tasks.deleteTrash');


### PR DESCRIPTION
## やったこと

* 『ゴミ箱を空にする』ボタンを押した時に、関係のないルーティングが実行されるエラーを修正

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* エラーなく、『ゴミ箱を空にする』ボタンを扱える

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* エラーが発生しないことを確認（目視）

## その他

* 無し